### PR TITLE
doc: link main module docs to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![Elixir CI status](https://github.com/zeam-vm/pelemay_backend/actions/workflows/ci.yml/badge.svg)](https://github.com/zeam-vm/pelemay_backend/actions/workflows/ci.yml/badge.svg) [![Nerves CI status](https://github.com/zeam-vm/pelemay_backend/actions/workflows/nerves-build.yml/badge.svg)](https://github.com/zeam-vm/pelemay_backend/actions/workflows/nerves-build.yml/badge.svg)
 
+<!-- MODULEDOC -->
+A memory-saving, fault-tolerant and distributed collection of Nx compilers and
+backends for embedded systems.
+<!-- MODULEDOC -->
 
 This repository currently holds the following projects:
 

--- a/backends/logging_backend/README.md
+++ b/backends/logging_backend/README.md
@@ -1,13 +1,15 @@
 # LoggingBackend
 
+<!-- MODULEDOC -->
 A backend to log the behavior of the specified `based_backend`.
+<!-- MODULEDOC -->
 
 ## Installation
 
 ```elixir
 def deps do
   [
-    {:logging_backend, "~> 0.1.0-dev", github: "zeam-vm/pelemay_backend", sparse: "backends/logging_backend"}, 
+    {:logging_backend, "~> 0.1.0-dev", github: "zeam-vm/pelemay_backend", sparse: "backends/logging_backend"},
     {:backend_decorator, "~> 0.1.0-dev", github: "zeam-vm/pelemay_backend", sparse: "utilities/backend_decorator", override: true}
   ]
 end

--- a/backends/logging_backend/lib/logging_backend.ex
+++ b/backends/logging_backend/lib/logging_backend.ex
@@ -1,7 +1,7 @@
 defmodule LoggingBackend do
-  @moduledoc """
-  A backend to log the behavior of the specified `based_backend`.
-  """
+  @moduledoc File.read!("README.md")
+             |> String.split("<!-- MODULEDOC -->")
+             |> Enum.fetch!(1)
 
   @doc """
   Hello world.

--- a/backends/pelemay_backend/README.md
+++ b/backends/pelemay_backend/README.md
@@ -1,6 +1,8 @@
 # PelemayBackend
 
+<!-- MODULEDOC -->
 **TODO: Add description**
+<!-- MODULEDOC -->
 
 ## Installation
 

--- a/backends/pelemay_backend/lib/pelemay_backend.ex
+++ b/backends/pelemay_backend/lib/pelemay_backend.ex
@@ -1,7 +1,7 @@
 defmodule PelemayBackend do
-  @moduledoc """
-  Documentation for `PelemayBackend`.
-  """
+  @moduledoc File.read!("README.md")
+             |> String.split("<!-- MODULEDOC -->")
+             |> Enum.fetch!(1)
 
   @doc """
   Hello world.

--- a/benchmarks/onnx_to_axon_bench/README.md
+++ b/benchmarks/onnx_to_axon_bench/README.md
@@ -1,13 +1,15 @@
 # OnnxToAxonBench
 
+<!-- MODULEDOC -->
 A benchmark program of loading ONNX to Axon.
+<!-- MODULEDOC -->
 
 ## Benchmark Results
 
-Here are the results that are obtained when running on an M2 MacBook Air: 
+Here are the results that are obtained when running on an M2 MacBook Air:
 
 ```
-% cd benchmarks/onnx_to_axon_bench 
+% cd benchmarks/onnx_to_axon_bench
 % mix run -e "OnnxToAxonBench.run"
 
 05:29:35.627 [info] File cats_v_dogs.onnx has already been downloaded.

--- a/benchmarks/onnx_to_axon_bench/lib/onnx_to_axon_bench.ex
+++ b/benchmarks/onnx_to_axon_bench/lib/onnx_to_axon_bench.ex
@@ -1,7 +1,8 @@
 defmodule OnnxToAxonBench do
-  @moduledoc """
-  Documentation for `OnnxToAxonBench`.
-  """
+  @moduledoc File.read!("README.md")
+             |> String.split("<!-- MODULEDOC -->")
+             |> Enum.fetch!(1)
+
   require Logger
 
   @spec run() :: any()

--- a/lib/pelemay_backend.ex
+++ b/lib/pelemay_backend.ex
@@ -1,2 +1,5 @@
 defmodule PelemayBackend do
+  @moduledoc File.read!("README.md")
+             |> String.split("<!-- MODULEDOC -->")
+             |> Enum.fetch!(1)
 end


### PR DESCRIPTION
Original PR is #122 by @mnishiguchi 

This allows us to write main description in README.md and copy the same text in the main moduledoc of each project.