### PR TITLE
refactor(OnnxToAxonBench): factor out inputs and test 

### DIFF
--- a/benchmarks/onnx_to_axon_bench/lib/onnx_to_axon_bench.ex
+++ b/benchmarks/onnx_to_axon_bench/lib/onnx_to_axon_bench.ex
@@ -11,9 +11,12 @@ defmodule OnnxToAxonBench do
     "https://github.com/onnx/models/raw/main/vision/classification/resnet/model/resnet101-v1-7.onnx"
   ]
 
-  @spec run() :: any()
-  def run() do
-    setup()
+  @spec run(keyword) :: :ok
+  def run(options \\ []) do
+    onnx_urls = options[:onnx_urls] || @onnx_urls
+
+    setup(onnx_urls)
+    inputs = benchee_inputs(onnx_urls)
 
     Benchee.run(
       %{
@@ -21,13 +24,16 @@ defmodule OnnxToAxonBench do
           get_axon_from_onnx(path_to_onnx)
         end
       },
-      inputs: benchee_inputs(),
+      inputs: inputs,
       memory_time: 2
     )
+
+    :ok
   end
 
-  def benchee_inputs() do
-    for onnx_url <- @onnx_urls, into: %{} do
+  @spec benchee_inputs([binary()]) :: %{binary() => binary()}
+  def benchee_inputs(onnx_urls) do
+    for onnx_url <- onnx_urls, into: %{} do
       basename = Path.basename(onnx_url)
       {basename, Path.join(path_models_onnx(), basename) }
     end
@@ -53,13 +59,13 @@ defmodule OnnxToAxonBench do
     Path.join(priv(), "data")
   end
 
-  @spec setup() :: :ok
-  def setup() do
+  @spec setup([binary()]) :: :ok
+  def setup(onnx_urls) do
     File.mkdir_p!(path_models_onnx())
     File.mkdir_p!(path_models_axon())
     File.mkdir_p!(path_data())
 
-    setup_onnx(@onnx_urls)
+    setup_onnx(onnx_urls)
 
     :ok
   end

--- a/benchmarks/onnx_to_axon_bench/lib/onnx_to_axon_bench.ex
+++ b/benchmarks/onnx_to_axon_bench/lib/onnx_to_axon_bench.ex
@@ -11,7 +11,7 @@ defmodule OnnxToAxonBench do
     "https://github.com/onnx/models/raw/main/vision/classification/resnet/model/resnet101-v1-7.onnx"
   ]
 
-  @spec run(keyword) :: :ok
+  @spec run(keyword()) :: :ok
   def run(options \\ []) do
     onnx_urls = options[:onnx_urls] || @onnx_urls
 
@@ -35,7 +35,7 @@ defmodule OnnxToAxonBench do
   def benchee_inputs(onnx_urls) do
     for onnx_url <- onnx_urls, into: %{} do
       basename = Path.basename(onnx_url)
-      {basename, Path.join(path_models_onnx(), basename) }
+      {basename, Path.join(path_models_onnx(), basename)}
     end
   end
 

--- a/benchmarks/onnx_to_axon_bench/lib/onnx_to_axon_bench.ex
+++ b/benchmarks/onnx_to_axon_bench/lib/onnx_to_axon_bench.ex
@@ -14,7 +14,6 @@ defmodule OnnxToAxonBench do
   @spec run() :: any()
   def run() do
     init()
-    setup_onnx(@onnx_urls)
 
     inputs =
       @onnx_urls
@@ -61,6 +60,10 @@ defmodule OnnxToAxonBench do
     File.mkdir_p!(path_models_onnx())
     File.mkdir_p!(path_models_axon())
     File.mkdir_p!(path_data())
+
+    setup_onnx(@onnx_urls)
+
+    :ok
   end
 
   @spec setup_onnx(list(String.t())) :: list(String.t())

--- a/benchmarks/onnx_to_axon_bench/lib/onnx_to_axon_bench.ex
+++ b/benchmarks/onnx_to_axon_bench/lib/onnx_to_axon_bench.ex
@@ -39,7 +39,7 @@ defmodule OnnxToAxonBench do
     end
   end
 
-  @spec priv() :: String.t()
+  @spec priv() :: binary()
   def priv() do
     Application.app_dir(:onnx_to_axon_bench, "priv")
   end
@@ -70,13 +70,12 @@ defmodule OnnxToAxonBench do
     :ok
   end
 
-  @spec setup_onnx(list(String.t())) :: list(String.t())
+  @spec setup_onnx([binary()]) :: [binary()]
   def setup_onnx(files) do
     OnnxToAxonBench.Utils.HTTP.download_files(files, path_models_onnx())
   end
 
-  @spec setup_data(list(String.t())) ::
-          list(:ok | {:ok, list({charlist(), String.t()})} | {:error, any()})
+  @spec setup_data([binary()]) :: [:ok | {:ok, [{charlist(), binary()}]} | {:error, any()}]
   def setup_data(files) do
     OnnxToAxonBench.Utils.HTTP.download_files(files, path_data())
 
@@ -86,8 +85,8 @@ defmodule OnnxToAxonBench do
     |> Enum.to_list()
   end
 
-  @spec extract_from_url(Req.url()) ::
-          :ok | {:ok, list({charlist(), String.t()})} | {:error, any()}
+  @spec extract_from_url(URI.t() | String.t()) ::
+          :ok | {:ok, [{charlist(), binary()}]} | {:error, any()}
   def extract_from_url(url) do
     Path.join(path_data(), OnnxToAxonBench.Utils.HTTP.basename_from_uri(url))
     |> File.read!()
@@ -95,7 +94,7 @@ defmodule OnnxToAxonBench do
   end
 
   @spec extract_tar_from_string(binary()) ::
-          :ok | {:ok, list({charlist(), String.t()})} | {:error, any()}
+          :ok | {:ok, [{charlist(), binary()}]} | {:error, any()}
   def extract_tar_from_string(contents) do
     :erl_tar.extract({:binary, contents}, [
       :compressed,
@@ -103,7 +102,7 @@ defmodule OnnxToAxonBench do
     ])
   end
 
-  @spec axon_name_from_onnx_path(binary()) :: String.t()
+  @spec axon_name_from_onnx_path(binary()) :: binary()
   def axon_name_from_onnx_path(onnx_path) do
     model_root = onnx_path |> Path.basename() |> Path.rootname()
     "#{model_root}.axon"

--- a/benchmarks/onnx_to_axon_bench/lib/onnx_to_axon_bench.ex
+++ b/benchmarks/onnx_to_axon_bench/lib/onnx_to_axon_bench.ex
@@ -5,23 +5,23 @@ defmodule OnnxToAxonBench do
 
   require Logger
 
+  @onnx_urls [
+    "https://huggingface.co/ScottMueller/Cats_v_Dogs.ONNX/resolve/main/cats_v_dogs.onnx",
+    "https://huggingface.co/ScottMueller/Cat_Dog_Breeds.ONNX/resolve/main/cat_dog_breeds.onnx",
+    "https://github.com/onnx/models/raw/main/vision/classification/resnet/model/resnet101-v1-7.onnx"
+  ]
+
   @spec run() :: any()
   def run() do
     init()
 
-    onnx_uri = [
-      "https://huggingface.co/ScottMueller/Cats_v_Dogs.ONNX/resolve/main/cats_v_dogs.onnx",
-      "https://huggingface.co/ScottMueller/Cat_Dog_Breeds.ONNX/resolve/main/cat_dog_breeds.onnx",
-      "https://github.com/onnx/models/raw/main/vision/classification/resnet/model/resnet101-v1-7.onnx"
-    ]
-
     inputs =
-      onnx_uri
+      @onnx_urls
       |> Enum.map(fn url -> OnnxToAxonBench.Utils.HTTP.basename_from_uri(url) end)
       |> Enum.map(fn basename -> {basename, basename} end)
       |> Map.new()
 
-    setup_onnx(onnx_uri)
+    setup_onnx(@onnx_urls)
 
     Benchee.run(
       %{

--- a/benchmarks/onnx_to_axon_bench/lib/onnx_to_axon_bench.ex
+++ b/benchmarks/onnx_to_axon_bench/lib/onnx_to_axon_bench.ex
@@ -13,13 +13,7 @@ defmodule OnnxToAxonBench do
 
   @spec run() :: any()
   def run() do
-    init()
-
-    inputs =
-      @onnx_urls
-      |> Enum.map(fn url -> OnnxToAxonBench.Utils.HTTP.basename_from_uri(url) end)
-      |> Enum.map(fn basename -> {basename, basename} end)
-      |> Map.new()
+    setup()
 
     Benchee.run(
       %{
@@ -27,12 +21,16 @@ defmodule OnnxToAxonBench do
           get_axon_from_onnx(path_to_onnx)
         end
       },
-      inputs: inputs,
-      before_each: fn basename ->
-        Path.join(path_models_onnx(), basename)
-      end,
+      inputs: benchee_inputs(),
       memory_time: 2
     )
+  end
+
+  def benchee_inputs() do
+    for onnx_url <- @onnx_urls, into: %{} do
+      basename = Path.basename(onnx_url)
+      {basename, Path.join(path_models_onnx(), basename) }
+    end
   end
 
   @spec priv() :: String.t()
@@ -55,8 +53,8 @@ defmodule OnnxToAxonBench do
     Path.join(priv(), "data")
   end
 
-  @spec init() :: :ok
-  def init() do
+  @spec setup() :: :ok
+  def setup() do
     File.mkdir_p!(path_models_onnx())
     File.mkdir_p!(path_models_axon())
     File.mkdir_p!(path_data())

--- a/benchmarks/onnx_to_axon_bench/lib/onnx_to_axon_bench.ex
+++ b/benchmarks/onnx_to_axon_bench/lib/onnx_to_axon_bench.ex
@@ -14,14 +14,13 @@ defmodule OnnxToAxonBench do
   @spec run() :: any()
   def run() do
     init()
+    setup_onnx(@onnx_urls)
 
     inputs =
       @onnx_urls
       |> Enum.map(fn url -> OnnxToAxonBench.Utils.HTTP.basename_from_uri(url) end)
       |> Enum.map(fn basename -> {basename, basename} end)
       |> Map.new()
-
-    setup_onnx(@onnx_urls)
 
     Benchee.run(
       %{

--- a/benchmarks/onnx_to_axon_bench/test/onnx_to_axon_bench_test.exs
+++ b/benchmarks/onnx_to_axon_bench/test/onnx_to_axon_bench_test.exs
@@ -1,4 +1,16 @@
 defmodule OnnxToAxonBenchTest do
   use ExUnit.Case
   doctest OnnxToAxonBench
+  alias OnnxToAxonBench
+
+  describe "benchee_inputs" do
+    test "returns a map of basename to onnx file path" do
+      onnx_src_urls = ["https://example.com/1/2/3/cats_v_dogs.onnx"]
+
+      %{"cats_v_dogs.onnx" => onnx_path} = OnnxToAxonBench.benchee_inputs(onnx_src_urls)
+
+      priv_dir = Application.app_dir(:onnx_to_axon_bench, "priv")
+      assert onnx_path == "#{priv_dir}/models/onnx/cats_v_dogs.onnx"
+    end
+  end
 end


### PR DESCRIPTION
Original PR is #121 by @mnishiguchi 

### Description

This pull requests factor out the `benchee_input/1` function that we provide to `Benchee.run/2`, then add a minimal test for it.

### Changes

- Move ONNX source urls to `@onnx_urls` module attribute
- Let `OnnxToAxonBench.run` accept option
- Simplify `OnnxToAxonBench.run`
- Add `OnnxToAxonBench.benchee_inputs`
- Standardize on `binary` type 
- Add minimal `OnnxToAxonBenchTest` and test `benchee_inputs` returning correct map

### Notes
- Strings can be either `String.t()` or `binary()` type. They are nice to be standardized within the file.
