### PR TITLE
docs:  style README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Backends:
 Utilities:
 
 * [`BackendDecorator`](https://github.com/zeam-vm/pelemay_backend/blob/main/utilities/backend_decorator#readme) (WIP) - A backend generator to decorate the specified `based_backend` with the functions before and after a set of functions in the backend. The set can be specified with the style of [AspectJ, which is an AOP language](https://en.wikipedia.org/wiki/Aspect-oriented_programming), and with grouping written in [hexdocs of Nx](https://hexdocs.pm/nx/Nx.html), for example, Aggregates, Backend, Conversion, and so on.
-* [`NodeActivator`](https://github.com/zeam-vm/pelemay_backend/blob/main/utilities/node_activator/README.md) - A module to activate VM nodes.
+* [`NodeActivator`](https://github.com/zeam-vm/pelemay_backend/blob/main/utilities/node_activator#readme) - A module to activate VM nodes.
 
 Benchmarks:
 
-* [`OnnxToAxonBench`](https://github.com/zeam-vm/pelemay_backend/blob/main/benchmarks/onnx_to_axon_bench/README.md) - A benchmark program of loading ONNX to Axon. The results deny the hope to use ResNet, which is one of popular models that perform image classification, for embedded systems due to too much memory consumption. This fact supports the concept of the Pelemay Backend.
+* [`OnnxToAxonBench`](https://github.com/zeam-vm/pelemay_backend/blob/main/benchmarks/onnx_to_axon_bench#readme) - A benchmark program of loading ONNX to Axon. The results deny the hope to use ResNet, which is one of popular models that perform image classification, for embedded systems due to too much memory consumption. This fact supports the concept of the Pelemay Backend.
 
 Each has their own README, which you can access above to learn more.
 

--- a/backends/pelemay_backend/README.md
+++ b/backends/pelemay_backend/README.md
@@ -1,25 +1,13 @@
 # PelemayBackend
 
 <!-- MODULEDOC -->
-**TODO: Add description**
+A memory-saving, fault-tolerant and distributed collection of Nx compilers and
+backends for embedded systems.
 <!-- MODULEDOC -->
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `pelemay_backend` to your list of dependencies in `mix.exs`:
-
-```elixir
-def deps do
-  [
-    {:pelemay_backend, "~> 0.1.0"}
-  ]
-end
-```
-
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/pelemay_backend>.
+TBD
 
 ## License
 

--- a/benchmarks/onnx_to_axon_bench/README.md
+++ b/benchmarks/onnx_to_axon_bench/README.md
@@ -8,7 +8,7 @@ A benchmark program of loading ONNX to Axon.
 
 Here are the results that are obtained when running on an M2 MacBook Air:
 
-```
+```elixir
 % cd benchmarks/onnx_to_axon_bench
 % mix run -e "OnnxToAxonBench.run"
 

--- a/utilities/backend_decorator/README.md
+++ b/utilities/backend_decorator/README.md
@@ -1,6 +1,8 @@
 # BackendDecorator
 
+<!-- MODULEDOC -->
 A backend generator to decorate the specified `based_backend` with the functions before and after a set of functions in the backend. The set can be specified with the style of [AspectJ, which is an AOP language](https://en.wikipedia.org/wiki/Aspect-oriented_programming), and with grouping written in [hexdocs of Nx](https://hexdocs.pm/nx/Nx.html), for example, Aggregates, Backend, Conversion, and so on.
+<!-- MODULEDOC -->
 
 ## Installation
 

--- a/utilities/backend_decorator/lib/backend_decorator.ex
+++ b/utilities/backend_decorator/lib/backend_decorator.ex
@@ -1,11 +1,5 @@
 defmodule BackendDecorator do
-  @moduledoc """
-  A backend generator to decorate the specified `based_backend`
-  with the functions before and after a set of functions in
-  the backend. The set can be specified with the style of
-  [AspectJ, which is an AOP language](https://en.wikipedia.org/wiki/Aspect-oriented_programming),
-  and with grouping written in
-  [hexdocs of Nx](https://hexdocs.pm/nx/Nx.html), for example,
-  Aggregates, Backend, Conversion, and so on.
-  """
+  @moduledoc File.read!("README.md")
+             |> String.split("<!-- MODULEDOC -->")
+             |> Enum.fetch!(1)
 end

--- a/utilities/node_activator/README.md
+++ b/utilities/node_activator/README.md
@@ -1,21 +1,9 @@
 # NodeActivator
 
+<!-- MODULEDOC -->
 A module to activate VM nodes.
+<!-- MODULEDOC -->
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `node_activator` to your list of dependencies in `mix.exs`:
-
-```elixir
-def deps do
-  [
-    {:node_activator, "~> 0.1.0"}
-  ]
-end
-```
-
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/node_activator>.
-
+TBD

--- a/utilities/node_activator/lib/node_activator.ex
+++ b/utilities/node_activator/lib/node_activator.ex
@@ -1,7 +1,8 @@
 defmodule NodeActivator do
-  @moduledoc """
-  A module to activate VM nodes.
-  """
+  @moduledoc File.read!("README.md")
+             |> String.split("<!-- MODULEDOC -->")
+             |> Enum.fetch!(1)
+
   require Logger
 
   @epmd_port 4369


### PR DESCRIPTION
### Changes
- specify language for benchmark example code
- standardize on `#readme` links 
- delete irrelevant text
- fill in missing intro text
