### PR TITLE
refactor: clean up OnnxToAxonBench

### DIFF
--- a/benchmarks/onnx_to_axon_bench/lib/onnx_to_axon_bench.ex
+++ b/benchmarks/onnx_to_axon_bench/lib/onnx_to_axon_bench.ex
@@ -4,6 +4,7 @@ defmodule OnnxToAxonBench do
              |> Enum.fetch!(1)
 
   require Logger
+  alias OnnxToAxonBench.Utils.HTTP
 
   @onnx_urls [
     "https://huggingface.co/ScottMueller/Cats_v_Dogs.ONNX/resolve/main/cats_v_dogs.onnx",
@@ -11,12 +12,21 @@ defmodule OnnxToAxonBench do
     "https://github.com/onnx/models/raw/main/vision/classification/resnet/model/resnet101-v1-7.onnx"
   ]
 
+  @doc """
+  Run the benchmark jobs for ONNX model URLs.
+
+  ## Examples
+
+      % cd benchmarks/onnx_to_axon_bench
+      % mix run -e "OnnxToAxonBench.run"
+  """
   @spec run(keyword()) :: :ok
   def run(options \\ []) do
     onnx_urls = options[:onnx_urls] || @onnx_urls
 
-    setup(onnx_urls)
-    inputs = benchee_inputs(onnx_urls)
+    File.mkdir_p!(onnx_models_dir())
+    HTTP.download_files(onnx_urls, onnx_models_dir())
+    inputs = onnx_urls_to_inputs(onnx_urls)
 
     Benchee.run(
       %{
@@ -31,95 +41,31 @@ defmodule OnnxToAxonBench do
     :ok
   end
 
-  @spec benchee_inputs([binary()]) :: %{binary() => binary()}
-  def benchee_inputs(onnx_urls) do
+  @doc """
+  Convert a list of ONNX model source URLs to a mapping of basename to the
+  path to the download model.
+  """
+  @spec onnx_urls_to_inputs([binary()]) :: %{binary() => binary()}
+  def onnx_urls_to_inputs(onnx_urls) do
     for onnx_url <- onnx_urls, into: %{} do
       basename = Path.basename(onnx_url)
-      {basename, Path.join(path_models_onnx(), basename)}
+      {basename, Path.join(onnx_models_dir(), basename)}
     end
   end
 
-  @spec priv() :: binary()
-  def priv() do
+  @spec priv_dir() :: binary()
+  defp priv_dir() do
     Application.app_dir(:onnx_to_axon_bench, "priv")
   end
 
-  @spec path_models_onnx() :: binary()
-  def path_models_onnx() do
-    Path.join(priv(), "models/onnx")
-  end
-
-  @spec path_models_axon() :: binary()
-  def path_models_axon() do
-    Path.join(priv(), "models/onnx")
-  end
-
-  @spec path_data() :: binary()
-  def path_data() do
-    Path.join(priv(), "data")
-  end
-
-  @spec setup([binary()]) :: :ok
-  def setup(onnx_urls) do
-    File.mkdir_p!(path_models_onnx())
-    File.mkdir_p!(path_models_axon())
-    File.mkdir_p!(path_data())
-
-    setup_onnx(onnx_urls)
-
-    :ok
-  end
-
-  @spec setup_onnx([binary()]) :: [binary()]
-  def setup_onnx(files) do
-    OnnxToAxonBench.Utils.HTTP.download_files(files, path_models_onnx())
-  end
-
-  @spec setup_data([binary()]) :: [:ok | {:ok, [{charlist(), binary()}]} | {:error, any()}]
-  def setup_data(files) do
-    OnnxToAxonBench.Utils.HTTP.download_files(files, path_data())
-
-    files
-    |> Flow.from_enumerable(max_demand: 1)
-    |> Flow.map(fn url -> extract_from_url(url) end)
-    |> Enum.to_list()
-  end
-
-  @spec extract_from_url(URI.t() | String.t()) ::
-          :ok | {:ok, [{charlist(), binary()}]} | {:error, any()}
-  def extract_from_url(url) do
-    Path.join(path_data(), OnnxToAxonBench.Utils.HTTP.basename_from_uri(url))
-    |> File.read!()
-    |> extract_tar_from_string()
-  end
-
-  @spec extract_tar_from_string(binary()) ::
-          :ok | {:ok, [{charlist(), binary()}]} | {:error, any()}
-  def extract_tar_from_string(contents) do
-    :erl_tar.extract({:binary, contents}, [
-      :compressed,
-      {:cwd, path_data() |> String.to_charlist()}
-    ])
-  end
-
-  @spec axon_name_from_onnx_path(binary()) :: binary()
-  def axon_name_from_onnx_path(onnx_path) do
-    model_root = onnx_path |> Path.basename() |> Path.rootname()
-    "#{model_root}.axon"
-  end
-
-  @spec axon_path_from_onnx_path(binary()) :: binary()
-  def axon_path_from_onnx_path(onnx_path) do
-    Path.join(path_models_axon(), axon_name_from_onnx_path(onnx_path))
+  @spec onnx_models_dir() :: binary()
+  defp onnx_models_dir() do
+    Path.join(priv_dir(), "models/onnx")
   end
 
   @spec get_axon_from_onnx(binary()) :: any()
-  def get_axon_from_onnx(path_to_onnx_file) do
-    path_to_onnx_file
-    |> AxonOnnx.import()
-    |> then(fn {_model, parameters} ->
-      # Keep model
-      Nx.serialize(parameters)
-    end)
+  defp get_axon_from_onnx(path_to_onnx_file) do
+    {_model, parameters} = AxonOnnx.import(path_to_onnx_file)
+    Nx.serialize(parameters)
   end
 end

--- a/benchmarks/onnx_to_axon_bench/lib/onnx_to_axon_bench/utils/http.ex
+++ b/benchmarks/onnx_to_axon_bench/lib/onnx_to_axon_bench/utils/http.ex
@@ -60,16 +60,16 @@ defmodule OnnxToAxonBench.Utils.HTTP do
     |> Map.update!(:private, &%{&1 | downloaded_size: new_downloaded_size})
   end
 
-  @spec basename_from_uri(url()) :: String.t()
+  @spec basename_from_uri(url() | struct()) :: String.t()
   def basename_from_uri(url) when is_binary(url) do
     Path.basename(url)
   end
 
-  def basename_from_uri(url) do
+  def basename_from_uri(url) when is_map_key(url, :path) do
     URI.parse(url) |> Map.get(:path) |> Path.basename()
   end
 
-  @spec download_files([url()], String.t()) :: list(String.t())
+  @spec download_files([url()], String.t()) :: [String.t()]
   def download_files(files, dst_path) do
     Enum.map(files, fn url ->
       basename = basename_from_uri(url)

--- a/benchmarks/onnx_to_axon_bench/test/onnx_to_axon_bench_test.exs
+++ b/benchmarks/onnx_to_axon_bench/test/onnx_to_axon_bench_test.exs
@@ -7,7 +7,7 @@ defmodule OnnxToAxonBenchTest do
     test "returns a map of basename to onnx file path" do
       onnx_src_urls = ["https://example.com/1/2/3/cats_v_dogs.onnx"]
 
-      %{"cats_v_dogs.onnx" => onnx_path} = OnnxToAxonBench.benchee_inputs(onnx_src_urls)
+      %{"cats_v_dogs.onnx" => onnx_path} = OnnxToAxonBench.onnx_urls_to_inputs(onnx_src_urls)
 
       priv_dir = Application.app_dir(:onnx_to_axon_bench, "priv")
       assert onnx_path == "#{priv_dir}/models/onnx/cats_v_dogs.onnx"


### PR DESCRIPTION
### Description

It seems many functions in `OnnxToAxonBench` modules are unused at least for running the benchmark jobs. So this pull request removes them. 

In case they need to stay, we will need to explain why and how we are supposed to use them.
