### PR TITLE
add OnnxToAxonBench basic usage

### DIFF
--- a/benchmarks/onnx_to_axon_bench/README.md
+++ b/benchmarks/onnx_to_axon_bench/README.md
@@ -2,6 +2,37 @@
 
 <!-- MODULEDOC -->
 A benchmark program of loading ONNX to Axon.
+
+## Usage
+
+The benchmark can be run in the interactive Elixir shell (IEx) like below.
+
+```elixir
+run_benchmarks = fn ->
+  Mix.install([
+    {
+      :onnx_to_axon_bench,
+      github: "zeam-vm/pelemay_backend",
+      sparse: "benchmarks/onnx_to_axon_bench"
+    }
+  ])
+
+  OnnxToAxonBench.run()
+
+  :ok
+end
+
+run_benchmarks.()
+```
+
+Alternatively, if you clone the source code, you can run the
+`OnnxToAxonBench.run/0` function via mix run task in the `onnx_to_axon_bench`
+project directory.
+
+```bash
+$ cd benchmarks/onnx_to_axon_bench
+$ mix run -e "OnnxToAxonBench.run"
+```
 <!-- MODULEDOC -->
 
 ## Benchmark Results
@@ -9,9 +40,6 @@ A benchmark program of loading ONNX to Axon.
 Here are the results that are obtained when running on an M2 MacBook Air:
 
 ```elixir
-% cd benchmarks/onnx_to_axon_bench
-% mix run -e "OnnxToAxonBench.run"
-
 05:29:35.627 [info] File cats_v_dogs.onnx has already been downloaded.
 
 05:29:35.628 [info] File cat_dog_breeds.onnx has already been downloaded.


### PR DESCRIPTION
This is an idea to present the visitor how to run the benchmark easily.