### PR TITLE
test(NodeActivator): add unit tests

### DIFF
--- a/utilities/node_activator/lib/node_activator.ex
+++ b/utilities/node_activator/lib/node_activator.ex
@@ -25,7 +25,7 @@ defmodule NodeActivator do
       Logger.info("done.")
       name = generate_node_name(node_name_prefix)
       Logger.info("Node.start(#{name})")
-      Node.start(name)
+      {:ok, _} = Node.start(name)
     end
 
     {:ok, Node.self()}

--- a/utilities/node_activator/lib/node_activator.ex
+++ b/utilities/node_activator/lib/node_activator.ex
@@ -10,23 +10,25 @@ defmodule NodeActivator do
   @doc """
   Activates Node.
   """
-  @spec run(binary()) :: {:ok, node() | pid()} | {:error, term()}
-  def run(name) do
-    if Node.alive?() do
-      {:ok, Node.self()}
-    else
-      case :os.type() do
-        {:unix, _} -> launch_epmd(port: @epmd_port)
-        {:win32, _} -> launch_epmd(port: @epmd_port, daemon: false)
-      end
+  @spec run(binary()) :: {:ok, node()}
+  def run(node_name_prefix) do
+    unless Node.alive?() do
+      empd_options =
+        case :os.type() do
+          {:unix, _} -> [port: @epmd_port]
+          {:win32, _} -> [port: @epmd_port, daemon: false]
+        end
 
+      launch_epmd(empd_options)
       Logger.info("wait launching epmd...")
       wait_launching_epmd(5)
       Logger.info("done.")
-      name = name |> name_with_random_key() |> String.to_atom()
+      name = generate_node_name(node_name_prefix)
       Logger.info("Node.start(#{name})")
       Node.start(name)
     end
+
+    {:ok, Node.self()}
   end
 
   defp wait_launching_epmd(0), do: raise(RuntimeError, "Fail to launch epmd.")
@@ -53,76 +55,83 @@ defmodule NodeActivator do
     end
   end
 
-  @spec name_with_random_key(binary()) :: binary()
-  def name_with_random_key(name) do
-    "#{name}_#{:crypto.strong_rand_bytes(5) |> Base.encode32(case: :lower)}@#{hostname_f()}"
+  @spec generate_node_name(binary()) :: atom()
+  def generate_node_name(prefix) do
+    prefix = Regex.replace(~r/\s/, prefix, "-")
+    random_string = :crypto.strong_rand_bytes(5) |> Base.encode32(case: :lower)
+
+    :"#{prefix}_#{random_string}@#{get_hostname()}"
   end
 
-  @spec hostname_f() :: binary()
-  def hostname_f() do
-    hostname = System.find_executable("hostname")
+  @spec get_hostname() :: binary()
+  def get_hostname() do
+    hostname_cmd = System.find_executable("hostname")
 
-    if is_nil(hostname) do
+    if is_nil(hostname_cmd) do
       raise RuntimeError, "Fail to find the \"hostname\" command."
-    else
-      {result, exit_code} =
-        case :os.type() do
-          {:unix, _} -> System.cmd(hostname, ["-f"])
-          {:win32, _} -> System.cmd(hostname, [])
-        end
-
-      if exit_code == 0 do
-        String.trim(result)
-      else
-        raise RuntimeError, "Fail to execute the \"hostname\" command."
-      end
     end
+
+    {result, exit_code} =
+      case :os.type() do
+        {:unix, _} -> System.cmd(hostname_cmd, ["-f"])
+        {:win32, _} -> System.cmd(hostname_cmd, [])
+      end
+
+    if exit_code > 0 do
+      raise RuntimeError, "Fail to execute the \"hostname\" command."
+    end
+
+    String.trim(result)
   end
 
   @spec launch_epmd(keyword) :: :ok
   def launch_epmd(options \\ [daemon: true]) do
-    options =
-      options
-      |> Enum.map(fn
-        {:adress, list} when is_binary(list) -> ["-address", list]
-        {:port, no} when is_integer(no) -> ["-port", "#{no}"]
-        {:debug, true} -> ["-debug"]
-        {:debug, false} -> []
-        {:daemon, true} -> ["-daemon"]
-        {:daemon, false} -> []
-        {:relaxed_command_check, true} -> ["-relaxed_command"]
-        {:relaxed_command_check, false} -> []
-        {:packet_timeout, seconds} when is_integer(seconds) -> ["-packet_timeout", "#{seconds}"]
-        {:delay_accept, seconds} when is_integer(seconds) -> ["-delay_accept", "#{seconds}"]
-        {:delay_write, seconds} when is_integer(seconds) -> ["-delay_write", "#{seconds}"]
-        {:kill, true} -> ["-kill"]
-        {:kill, false} -> []
-        {:names, true} -> ["-names"]
-        {:names, false} -> []
-        {:stop, name} when is_binary(name) -> ["-stop", name]
-      end)
-      |> List.flatten()
+    epmd_cmd = System.find_executable("epmd")
+    epmd_options = epmd_options_to_list(options)
 
-    epmd_path = System.find_executable("epmd")
-
-    if is_nil(epmd_path) do
+    if is_nil(epmd_cmd) do
       Logger.error("Fail to find epmd.")
       raise RuntimeError, "Fail to find epmd."
+    end
+
+    spawn_link(fn -> do_launch_epmd(epmd_cmd, epmd_options) end)
+
+    :ok
+  end
+
+  defp do_launch_epmd(epmd_cmd, epmd_options) do
+    {result, exit_code} = System.cmd(epmd_cmd, epmd_options, parallelism: true)
+
+    options_and_result = "#{Enum.join(epmd_options, " ")}: #{result}"
+
+    if exit_code == 0 do
+      Logger.info("epmd " <> options_and_result)
     else
-      spawn_link(fn -> launch_epmd(epmd_path, options) end)
-      :ok
+      Logger.error("epmd " <> options_and_result <> ": error_code: #{exit_code}")
+      raise RuntimeError, "Fail to launch epmd " <> options_and_result
     end
   end
 
-  defp launch_epmd(epmd_path, options) do
-    {result, exit_code} = System.cmd(epmd_path, options, parallelism: true)
-
-    if exit_code == 0 do
-      Logger.info("epmd #{Enum.join(options, " ")}: #{result}")
-    else
-      # credo:disable-for-next-line
-      Logger.error("epmd #{Enum.join(options, " ")}: #{result}", error_code: exit_code)
-      raise RuntimeError, "Fail to launch epmd #{Enum.join(options, " ")}: #{result}"
-    end
+  @spec epmd_options_to_list(keyword) :: [binary()]
+  defp epmd_options_to_list(options) do
+    Enum.map(options, fn
+      {:adress, list} when is_binary(list) -> ["-address", list]
+      {:port, no} when is_integer(no) -> ["-port", "#{no}"]
+      {:debug, true} -> ["-debug"]
+      {:debug, false} -> []
+      {:daemon, true} -> ["-daemon"]
+      {:daemon, false} -> []
+      {:relaxed_command_check, true} -> ["-relaxed_command"]
+      {:relaxed_command_check, false} -> []
+      {:packet_timeout, seconds} when is_integer(seconds) -> ["-packet_timeout", "#{seconds}"]
+      {:delay_accept, seconds} when is_integer(seconds) -> ["-delay_accept", "#{seconds}"]
+      {:delay_write, seconds} when is_integer(seconds) -> ["-delay_write", "#{seconds}"]
+      {:kill, true} -> ["-kill"]
+      {:kill, false} -> []
+      {:names, true} -> ["-names"]
+      {:names, false} -> []
+      {:stop, name} when is_binary(name) -> ["-stop", name]
+    end)
+    |> List.flatten()
   end
 end

--- a/utilities/node_activator/test/node_activator_test.exs
+++ b/utilities/node_activator/test/node_activator_test.exs
@@ -2,13 +2,64 @@ defmodule NodeActivatorTest do
   use ExUnit.Case
   doctest NodeActivator
 
-  test "run" do
-    NodeActivator.run("test")
-
-    assert Node.alive?() == true
+  setup do
+    on_exit(fn -> Node.stop() end)
   end
 
-  test "launch_epmd" do
-    assert NodeActivator.launch_epmd() == :ok
+  describe "run" do
+    test "starts node with correct name" do
+      refute Node.alive?()
+
+      {:ok, node_name} = NodeActivator.run("test prefix")
+
+      assert Node.alive?()
+      assert Node.self() == node_name
+      assert "test-prefix" <> <<_::binary>> = to_string(node_name)
+    end
+
+    test "is idempotent" do
+      {:ok, node_name1} = NodeActivator.run("test prefix")
+      {:ok, node_name2} = NodeActivator.run("test prefix")
+
+      assert node_name1 == node_name2
+    end
+  end
+
+  describe "generate_node_name" do
+    test "generates unique atom" do
+      node_name1 = NodeActivator.generate_node_name("test prefix")
+      node_name2 = NodeActivator.generate_node_name("test prefix")
+
+      assert is_atom(node_name1)
+      refute node_name1 == node_name2
+    end
+
+    test "starts with provided prefix" do
+      node_name = NodeActivator.generate_node_name("test prefix")
+
+      assert node_name |> Atom.to_string() |> String.starts_with?("test-prefix_")
+    end
+
+    test "ends with hostname" do
+      node_name = NodeActivator.generate_node_name("test prefix")
+
+      {:ok, hostname} = :inet.gethostname()
+      assert node_name |> Atom.to_string() |> String.ends_with?(to_string(hostname))
+    end
+  end
+
+  describe "get_hostname" do
+    test "returns non-blank string" do
+      hostname = NodeActivator.get_hostname()
+
+      assert is_binary(hostname)
+      assert String.length(hostname) > 1
+    end
+  end
+
+  describe "launch_epmd" do
+    test "does not raise error" do
+      assert :ok = NodeActivator.launch_epmd()
+    end
   end
 end

--- a/utilities/node_activator/test/node_activator_test.exs
+++ b/utilities/node_activator/test/node_activator_test.exs
@@ -42,9 +42,9 @@ defmodule NodeActivatorTest do
 
     test "ends with hostname" do
       node_name = NodeActivator.generate_node_name("test prefix")
+      hostname = NodeActivator.get_hostname()
 
-      {:ok, hostname} = :inet.gethostname()
-      assert node_name |> Atom.to_string() |> String.ends_with?(to_string(hostname))
+      assert node_name |> Atom.to_string() |> String.ends_with?(hostname)
     end
   end
 


### PR DESCRIPTION
Add unit test. Also improve some module structure with readability in mind. The functionality is unchanged except the return value of `run` function now always returning node.

- let `run` return consistent value 
  - was pid or node; now always node 
- make nesting conditionals shallower for readability
- rename some variables and functions for self-explaining
- factor private functions out of larger functions
- handle space in node name
  - was failing silently; now replace space with hyphen 
- fix based on credo warning