### PR TITLE
docs(SpawnCoElixir): fill in function function docs etc

### DIFF
--- a/utilities/spawn_co_elixir/README.md
+++ b/utilities/spawn_co_elixir/README.md
@@ -1,11 +1,12 @@
 # SpawnCoElixir
 
-**TODO: Add description**
+<!-- MODULEDOC -->
+SpawnCoElixir spawns cooperative Elixir nodes that are supervised.
+<!-- MODULEDOC -->
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `spawn_co_elixir` to your list of dependencies in `mix.exs`:
+Just add `spawn_co_elixir` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
@@ -15,7 +16,5 @@ def deps do
 end
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/spawn_co_elixir>.
+Documentation can be found at <https://hexdocs.pm/spawn_co_elixir>.
 

--- a/utilities/spawn_co_elixir/lib/spawn_co_elixir.ex
+++ b/utilities/spawn_co_elixir/lib/spawn_co_elixir.ex
@@ -1,21 +1,45 @@
 defmodule SpawnCoElixir do
-  @moduledoc """
-  Documentation for `SpawnCoElixir`.
+  @moduledoc File.read!("README.md")
+             |> String.split("<!-- MODULEDOC -->")
+             |> Enum.fetch!(1)
+
+  @typedoc """
+  The CoElixir server option
+
+  * `:code` - Elixir code to be run by SpawnCoElixir.CoElixir.Worker
+  * `:host_name` - the node name prefix for host
+  * `:co_elixir_name` - the node name prefix for CoElixir
   """
+  @type co_elixir_options ::
+          {:code, binary}
+          | {:host_name, binary}
+          | {:co_elixir_name, binary}
 
-  def init() do
-    :ets.new(:spawn_co_elixir_co_elixir_lookup, [:set, :public, :named_table])
-  end
+  @doc """
+  Starts a CoElixir server as a child of `SpawnCoElixir.DynamicSupervisor`.
+  """
+  @spec run([co_elixir_options]) :: {:ok, pid}
+  def run(options \\ []) do
+    co_elixir_options = [
+      code: options[:code] || "",
+      host_name: options[:host_name] || "host",
+      co_elixir_name: options[:co_elixir_name] || "co_elixir"
+    ]
 
-  def run(options \\ [code: "", host_name: "host", co_elixir_name: "co_elixir"]) do
     {:ok, _pid} =
       DynamicSupervisor.start_child(
         SpawnCoElixir.DynamicSupervisor,
-        {SpawnCoElixir.CoElixir, %{options: options}}
+        {SpawnCoElixir.CoElixir, %{options: co_elixir_options}}
       )
   end
 
+  @doc """
+  Stops a CoElixir server.
+  """
   defdelegate stop(worker_node), to: SpawnCoElixir.CoElixir
 
+  @doc """
+  Lists all running CoElixir servers.
+  """
   defdelegate workers, to: SpawnCoElixir.CoElixir
 end

--- a/utilities/spawn_co_elixir/lib/spawn_co_elixir/application.ex
+++ b/utilities/spawn_co_elixir/lib/spawn_co_elixir/application.ex
@@ -7,7 +7,7 @@ defmodule SpawnCoElixir.Application do
 
   @impl true
   def start(_type, _args) do
-    SpawnCoElixir.init()
+    init_co_elixir_lookup()
 
     children = [
       # Starts a worker by calling: SpawnCoElixir.Worker.start_link(arg)
@@ -19,5 +19,10 @@ defmodule SpawnCoElixir.Application do
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: SpawnCoElixir.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  defp init_co_elixir_lookup() do
+    _ref = :ets.new(:spawn_co_elixir_co_elixir_lookup, [:set, :public, :named_table])
+    :ok
   end
 end

--- a/utilities/spawn_co_elixir/lib/spawn_co_elixir/co_elixir.ex
+++ b/utilities/spawn_co_elixir/lib/spawn_co_elixir/co_elixir.ex
@@ -1,7 +1,5 @@
 defmodule SpawnCoElixir.CoElixir do
-  @moduledoc """
-  SpawnCoElixir.CoElixir
-  """
+  @moduledoc false
 
   use GenServer
   require Logger


### PR DESCRIPTION
### Description
Fill in basic documents.

### Notes
- It is nice to ensure options are built correctly in `SpawnCoElixir.run/1`.
- The `spawn_co_elixir_co_elixir_lookup` ETS table seems private and it is used internally. So I moved it to a private location. In case it needs to be exposed, we could put it back to the original place.