### PR TITLE
refactor(SpawnCoElixir): factor out ets as CoElixirLookup

### DIFF
--- a/utilities/spawn_co_elixir/lib/spawn_co_elixir.ex
+++ b/utilities/spawn_co_elixir/lib/spawn_co_elixir.ex
@@ -10,7 +10,7 @@ defmodule SpawnCoElixir do
   * `:host_name` - the node name prefix for host
   * `:co_elixir_name` - the node name prefix for CoElixir
   """
-  @type co_elixir_options ::
+  @type co_elixir_option ::
           {:code, binary}
           | {:host_name, binary}
           | {:co_elixir_name, binary}
@@ -18,7 +18,7 @@ defmodule SpawnCoElixir do
   @doc """
   Starts a CoElixir server as a child of `SpawnCoElixir.DynamicSupervisor`.
   """
-  @spec run([co_elixir_options]) :: {:ok, pid}
+  @spec run([co_elixir_option]) :: {:ok, pid}
   def run(options \\ []) do
     co_elixir_options = [
       code: options[:code] || "",

--- a/utilities/spawn_co_elixir/lib/spawn_co_elixir/application.ex
+++ b/utilities/spawn_co_elixir/lib/spawn_co_elixir/application.ex
@@ -5,9 +5,11 @@ defmodule SpawnCoElixir.Application do
 
   use Application
 
+  alias SpawnCoElixir.CoElixirLookup
+
   @impl true
   def start(_type, _args) do
-    init_co_elixir_lookup()
+    CoElixirLookup.create_table()
 
     children = [
       # Starts a worker by calling: SpawnCoElixir.Worker.start_link(arg)
@@ -19,10 +21,5 @@ defmodule SpawnCoElixir.Application do
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: SpawnCoElixir.Supervisor]
     Supervisor.start_link(children, opts)
-  end
-
-  defp init_co_elixir_lookup() do
-    _ref = :ets.new(:spawn_co_elixir_co_elixir_lookup, [:set, :public, :named_table])
-    :ok
   end
 end

--- a/utilities/spawn_co_elixir/lib/spawn_co_elixir/co_elixir_lookup.ex
+++ b/utilities/spawn_co_elixir/lib/spawn_co_elixir/co_elixir_lookup.ex
@@ -52,4 +52,10 @@ defmodule SpawnCoElixir.CoElixirLookup do
     true = :ets.delete(@table_name, worker_node)
     :ok
   end
+
+  @spec delete_all() :: :ok
+  def delete_all() do
+    true = :ets.delete_all_objects(@table_name)
+    :ok
+  end
 end

--- a/utilities/spawn_co_elixir/lib/spawn_co_elixir/co_elixir_lookup.ex
+++ b/utilities/spawn_co_elixir/lib/spawn_co_elixir/co_elixir_lookup.ex
@@ -1,0 +1,55 @@
+defmodule SpawnCoElixir.CoElixirLookup do
+  @moduledoc false
+
+  @table_name :spawn_co_elixir_co_elixir_lookup
+
+  ## table operations
+
+  @spec create_table() :: :ok
+  def create_table() do
+    _ref = :ets.new(@table_name, [:set, :public, :named_table])
+    :ok
+  rescue
+    _ -> {:error, {:already_exists, @table_name}}
+  end
+
+  @spec delete_table() :: :ok
+  def delete_table() do
+    if table_exist?(), do: :ets.delete(@table_name)
+    :ok
+  end
+
+  @spec table_exist?() :: boolean()
+  def table_exist?() do
+    :ets.whereis(@table_name) != :undefined
+  end
+
+  ## read operations
+
+  @spec list_worker_nodes() :: [node]
+  def list_worker_nodes() do
+    :ets.select(@table_name, [{{:"$1", :"$2"}, [], [:"$1"]}])
+  end
+
+  @spec get_worker_pid(node) :: pid | nil
+  def get_worker_pid(worker_node) when is_atom(worker_node) do
+    case :ets.lookup(@table_name, worker_node) do
+      [] -> nil
+      [{^worker_node, pid}] -> pid
+    end
+  end
+
+  ## write operations
+
+  @spec put_entry(node, pid) :: :ok
+  def put_entry(worker_node, pid) when is_atom(worker_node) and is_pid(pid) do
+    true = :ets.insert(@table_name, {worker_node, pid})
+    :ok
+  end
+
+  @spec delete_entry(node) :: :ok
+  def delete_entry(worker_node) when is_atom(worker_node) do
+    true = :ets.delete(@table_name, worker_node)
+    :ok
+  end
+end

--- a/utilities/spawn_co_elixir/test/spawn_co_elixir/co_elixir_lookup_test.exs
+++ b/utilities/spawn_co_elixir/test/spawn_co_elixir/co_elixir_lookup_test.exs
@@ -26,6 +26,9 @@ defmodule SpawnCoElixir.CoElixirLookupTest do
 
     :ok = CoElixirLookup.delete_entry(:foo_node)
     assert CoElixirLookup.list_worker_nodes() == [:bar_node]
+
+    :ok = CoElixirLookup.delete_all()
+    assert CoElixirLookup.list_worker_nodes() == []
   end
 
   # makes a fake worker pid

--- a/utilities/spawn_co_elixir/test/spawn_co_elixir/co_elixir_lookup_test.exs
+++ b/utilities/spawn_co_elixir/test/spawn_co_elixir/co_elixir_lookup_test.exs
@@ -1,0 +1,36 @@
+defmodule SpawnCoElixir.CoElixirLookupTest do
+  use ExUnit.Case
+  doctest SpawnCoElixir.CoElixirLookup
+  alias SpawnCoElixir.CoElixirLookup
+
+  test "table is already started by application" do
+    assert CoElixirLookup.table_exist?()
+
+    assert {:error, {:already_exists, :spawn_co_elixir_co_elixir_lookup}} =
+             CoElixirLookup.create_table()
+  end
+
+  test "basic read write operations" do
+    assert CoElixirLookup.list_worker_nodes() == []
+
+    foo_pid = make_pid()
+    :ok = CoElixirLookup.put_entry(:foo_node, foo_pid)
+    assert CoElixirLookup.list_worker_nodes() == [:foo_node]
+
+    bar_pid = make_pid()
+    :ok = CoElixirLookup.put_entry(:bar_node, bar_pid)
+    assert CoElixirLookup.list_worker_nodes() == [:foo_node, :bar_node]
+
+    assert CoElixirLookup.get_worker_pid(:foo_node) == foo_pid
+    assert CoElixirLookup.get_worker_pid(:bar_node) == bar_pid
+
+    :ok = CoElixirLookup.delete_entry(:foo_node)
+    assert CoElixirLookup.list_worker_nodes() == [:bar_node]
+  end
+
+  # makes a fake worker pid
+  defp make_pid do
+    {:ok, pid} = Task.start_link(fn -> :ok end)
+    pid
+  end
+end


### PR DESCRIPTION
### Description
Make a dedicated module for ETS-related code and test its behavior separately.

### Notes
- rename `co_elixir_options` which is supposed to be singular
- use match spec instead of dumping all records with `:ets.tab2list`