### PR TITLE
refactor(SpawnCoElixir): CoElixir options

### DIFF
--- a/utilities/spawn_co_elixir/lib/spawn_co_elixir.ex
+++ b/utilities/spawn_co_elixir/lib/spawn_co_elixir.ex
@@ -6,12 +6,14 @@ defmodule SpawnCoElixir do
   @typedoc """
   The CoElixir server option
 
-  * `:code` - Elixir code to be run by SpawnCoElixir.CoElixir.Worker
+  * `:code` - Elixir code to be run by `CoElixir.Worker`
+  * `:deps` - dependencies for `CoElixir.Worker`
   * `:host_name` - the node name prefix for host
-  * `:co_elixir_name` - the node name prefix for CoElixir
+  * `:co_elixir_name` - the node name prefix for `CoElixir`
   """
   @type co_elixir_option ::
           {:code, binary}
+          | {:deps, [atom | tuple]}
           | {:host_name, binary}
           | {:co_elixir_name, binary}
 
@@ -22,6 +24,7 @@ defmodule SpawnCoElixir do
   def run(options \\ []) do
     co_elixir_options = [
       code: options[:code] || "",
+      deps: options[:deps] || [],
       host_name: options[:host_name] || "host",
       co_elixir_name: options[:co_elixir_name] || "co_elixir"
     ]
@@ -29,7 +32,7 @@ defmodule SpawnCoElixir do
     {:ok, _pid} =
       DynamicSupervisor.start_child(
         SpawnCoElixir.DynamicSupervisor,
-        {SpawnCoElixir.CoElixir, %{options: co_elixir_options}}
+        {SpawnCoElixir.CoElixir, co_elixir_options}
       )
   end
 

--- a/utilities/spawn_co_elixir/lib/spawn_co_elixir/co_elixir.ex
+++ b/utilities/spawn_co_elixir/lib/spawn_co_elixir/co_elixir.ex
@@ -5,32 +5,30 @@ defmodule SpawnCoElixir.CoElixir do
   require Logger
   alias SpawnCoElixir.CoElixirLookup
 
+  ## GenServer callbacks
+
   @impl true
-  def init(a_process \\ %{options: [code: "", host_name: "host", co_elixir_name: "co_elixir"]}) do
+  def init(options \\ []) do
+    a_process = %{options: options, running: false, worker_node: nil}
+
     {:ok, a_process}
   end
 
   @impl true
   def handle_cast(:spawn_co_elixir, a_process) do
-    unless a_process[:running] do
+    unless a_process.running do
       ret = self()
-      spawn_link(fn -> handle_cast_s(spawn_co_elixir(ret, a_process), ret) end)
+      spawn_link(fn -> handle_cast_s(spawn_co_elixir(ret, a_process.options), ret) end)
     end
 
-    {
-      :noreply,
-      Map.put(a_process, :running, true)
-    }
+    {:noreply, %{a_process | running: true}}
   end
 
   @impl true
   def handle_cast({:worker_node, worker_node}, a_process) do
     Logger.info("Register worker #{inspect(worker_node)}")
 
-    {
-      :noreply,
-      Map.put(a_process, :worker_node, worker_node)
-    }
+    {:noreply, %{a_process | worker_node: worker_node}}
   end
 
   @impl true
@@ -39,53 +37,34 @@ defmodule SpawnCoElixir.CoElixir do
       nil ->
         Logger.error("Not found worker_node")
 
-        {
-          :noreply,
-          a_process
-          |> Map.put(:running, false)
-        }
+        {:noreply, %{a_process | running: false}}
 
       :stopped ->
-        {
-          :noreply,
-          a_process
-          |> Map.put(:running, false)
-          |> Map.put(:worker_node, nil)
-        }
+        {:noreply, %{a_process | running: false, worker_node: nil}}
 
       worker_node ->
         Logger.info("Exit #{inspect(worker_node)}")
         Node.spawn(worker_node, System, :halt, [])
         CoElixirLookup.delete_entry(worker_node)
 
-        {
-          :noreply,
-          a_process
-          |> Map.put(:running, false)
-          |> Map.put(:worker_node, :stopped)
-        }
+        {:noreply, %{a_process | running: false, worker_node: :stopped}}
     end
   end
 
-  def start_link(
-        a_process \\ %{options: [code: "", host_name: "host", co_elixir_name: "co_elixir"]}
-      ) do
-    case Map.get(a_process, :options) do
-      nil ->
-        {:error, "No match options: #{inspect(a_process)}."}
+  ## Client API
 
-      options ->
-        case options[:host_name] do
-          nil ->
-            {:error, "No match host_name: #{inspect(a_process)}."}
+  def start_link(options \\ []) do
+    server_options = [
+      co_elixir_name: Keyword.fetch!(options, :co_elixir_name),
+      code: Keyword.fetch!(options, :code),
+      deps: Keyword.fetch!(options, :deps),
+      host_name: Keyword.fetch!(options, :host_name)
+    ]
 
-          host_prefix ->
-            NodeActivator.run(host_prefix)
-            {:ok, pid} = GenServer.start_link(__MODULE__, a_process)
-            GenServer.cast(pid, :spawn_co_elixir)
-            {:ok, pid}
-        end
-    end
+    NodeActivator.run(server_options[:host_name])
+    {:ok, pid} = GenServer.start_link(__MODULE__, server_options)
+    GenServer.cast(pid, :spawn_co_elixir)
+    {:ok, pid}
   end
 
   def workers() do
@@ -115,21 +94,16 @@ defmodule SpawnCoElixir.CoElixir do
     GenServer.cast(ret, :spawn_co_elixir)
   end
 
-  defp spawn_co_elixir(pid, a_process) do
-    options = a_process[:options]
-    code = options[:code]
-    worker_node = NodeActivator.Utils.generate_node_name(options[:co_elixir_name])
+  defp spawn_co_elixir(pid, options) do
+    code = Keyword.fetch!(options, :code)
+    deps = Keyword.fetch!(options, :deps)
+    node_name_prefix = Keyword.fetch!(options, :co_elixir_name)
 
+    worker_node = NodeActivator.Utils.generate_node_name(node_name_prefix)
     :ok = CoElixirLookup.put_entry(worker_node, pid)
 
     try do
       GenServer.cast(pid, {:worker_node, worker_node})
-
-      deps =
-        case options[:deps] do
-          nil -> []
-          deps -> deps
-        end
 
       program = """
       defmodule SpawnCoElixir.CoElixir.Worker do


### PR DESCRIPTION
### Description
Currently the validation for option keys is loose. This pull request aims to make the option check more strict.

Also I move some code around for potentially better readability.

### Changes
- Add `:deps` to `co_elixir_option` type and adjust related code
- Simplify options for `SpawnCoElixir.CoElixir.start_link`
- Use `Keyword.fetch!` for stricter key check in more locations
- Use the `.` notation to access `a_process` for key check
- Use the `%{a_processs | key: value}` pattern for key check instead of `Map.put`
- Move CoElixir client API code to the top of the file
- Declare the entire picture of the state in the `init` callback

