### PR TITLE
docs(SpawnCoElixir): add function specs

### DIFF
--- a/utilities/spawn_co_elixir/lib/spawn_co_elixir.ex
+++ b/utilities/spawn_co_elixir/lib/spawn_co_elixir.ex
@@ -18,9 +18,9 @@ defmodule SpawnCoElixir do
           | {:co_elixir_name, binary}
 
   @doc """
-  Starts a CoElixir server as a child of `SpawnCoElixir.DynamicSupervisor`.
+  Starts a supervised CoElixir worker.
   """
-  @spec run([co_elixir_option]) :: {:ok, pid}
+  @spec run([co_elixir_option]) :: DynamicSupervisor.on_start_child()
   def run(options \\ []) do
     co_elixir_options = [
       code: options[:code] || "",
@@ -29,20 +29,21 @@ defmodule SpawnCoElixir do
       co_elixir_name: options[:co_elixir_name] || "co_elixir"
     ]
 
-    {:ok, _pid} =
-      DynamicSupervisor.start_child(
-        SpawnCoElixir.DynamicSupervisor,
-        {SpawnCoElixir.CoElixir, co_elixir_options}
-      )
+    DynamicSupervisor.start_child(
+      SpawnCoElixir.DynamicSupervisor,
+      {SpawnCoElixir.CoElixir, co_elixir_options}
+    )
   end
 
   @doc """
-  Stops a CoElixir server.
+  Stops a CoElixir worker by node name.
   """
+  @spec stop(node) :: :ok
   defdelegate stop(worker_node), to: SpawnCoElixir.CoElixir
 
   @doc """
-  Lists all running CoElixir servers.
+  Lists all running CoElixir worker nodes.
   """
-  defdelegate workers, to: SpawnCoElixir.CoElixir
+  @spec workers :: [node]
+  defdelegate workers, to: SpawnCoElixir.CoElixirLookup, as: :list_worker_nodes
 end

--- a/utilities/spawn_co_elixir/lib/spawn_co_elixir/co_elixir.ex
+++ b/utilities/spawn_co_elixir/lib/spawn_co_elixir/co_elixir.ex
@@ -7,6 +7,7 @@ defmodule SpawnCoElixir.CoElixir do
 
   ## Client API
 
+  @spec start_link([SpawnCoElixir.co_elixir_option()]) :: {:ok, pid}
   def start_link(options \\ []) do
     server_options = [
       co_elixir_name: Keyword.fetch!(options, :co_elixir_name),
@@ -21,10 +22,7 @@ defmodule SpawnCoElixir.CoElixir do
     {:ok, pid}
   end
 
-  def workers() do
-    CoElixirLookup.list_worker_nodes()
-  end
-
+  @spec stop(node) :: :ok
   def stop(worker_node) do
     case CoElixirLookup.get_worker_pid(worker_node) do
       nil ->


### PR DESCRIPTION
### Description

This pull request adds function specs and does some minor adjustments.

### Notes
- Currently no module is using `CoElixir.workers/0` so I delete it and instead alias `SpawnCoElixir.workers/0` directly to `CoElixirLookup.list_worker_nodes/0`.
- From the user perspective, probably it would be helpful if `SpawnCoElixir.run/1` returns `DynamicSupervisor.on_start_child` type value rather than raise the match error.