### PR TITLE
refactor(SpawnCoElixir): add CoElixirWorkerSpawner and refactor

### DIFF
--- a/utilities/spawn_co_elixir/lib/spawn_co_elixir/co_elixir.ex
+++ b/utilities/spawn_co_elixir/lib/spawn_co_elixir/co_elixir.ex
@@ -55,10 +55,10 @@ defmodule SpawnCoElixir.CoElixir do
   end
 
   @impl true
-  def handle_cast({:worker_node, worker_node}, a_process) do
+  def handle_call({:worker_node, worker_node}, _from, a_process) do
     Logger.info("Register worker #{inspect(worker_node)}")
 
-    {:noreply, %{a_process | worker_node: worker_node}}
+    {:reply, :ok, %{a_process | worker_node: worker_node}}
   end
 
   @impl true
@@ -101,7 +101,7 @@ defmodule SpawnCoElixir.CoElixir do
     :ok = CoElixirLookup.put_entry(worker_node, pid)
 
     try do
-      GenServer.cast(pid, {:worker_node, worker_node})
+      :ok = GenServer.call(pid, {:worker_node, worker_node})
 
       program = """
       defmodule SpawnCoElixir.CoElixir.Worker do

--- a/utilities/spawn_co_elixir/lib/spawn_co_elixir/co_elixir_worker_spawner.ex
+++ b/utilities/spawn_co_elixir/lib/spawn_co_elixir/co_elixir_worker_spawner.ex
@@ -6,11 +6,18 @@ defmodule SpawnCoElixir.CoElixirWorkerSpawner do
     code = Keyword.fetch!(options, :code)
     deps = Keyword.fetch!(options, :deps)
 
+    name_or_sname =
+      if "#{worker_node}" =~ "." do
+        "--name"
+      else
+        "--sname"
+      end
+
     {_, exit_status} =
       System.cmd(
         "elixir",
         [
-          "--sname",
+          name_or_sname,
           Atom.to_string(worker_node),
           "-e",
           build_program(node_from, code, deps)

--- a/utilities/spawn_co_elixir/lib/spawn_co_elixir/co_elixir_worker_spawner.ex
+++ b/utilities/spawn_co_elixir/lib/spawn_co_elixir/co_elixir_worker_spawner.ex
@@ -1,0 +1,51 @@
+defmodule SpawnCoElixir.CoElixirWorkerSpawner do
+  @moduledoc false
+
+  @spec run(node, node, keyword) :: :ok | {:error, non_neg_integer}
+  def run(node_from, worker_node, options) do
+    code = Keyword.fetch!(options, :code)
+    deps = Keyword.fetch!(options, :deps)
+
+    {_, exit_status} =
+      System.cmd(
+        "elixir",
+        [
+          "--sname",
+          Atom.to_string(worker_node),
+          "-e",
+          build_program(node_from, code, deps)
+        ],
+        into: IO.stream()
+      )
+
+    if exit_status == 0 do
+      :ok
+    else
+      {:error, exit_status}
+    end
+  end
+
+  defp build_program(node_from, code, deps) do
+    """
+    defmodule SpawnCoElixir.CoElixir.Worker do
+      def run() do
+        Mix.install(#{inspect(deps)})
+
+        #{code}
+
+        receive do
+          :end -> :ok
+        end
+      end
+    end
+
+    case Node.connect(:"#{node_from}") do
+      true ->
+        SpawnCoElixir.CoElixir.Worker.run()
+        :ok
+
+      _ -> raise RuntimeError, "could not connect to #{node_from}"
+    end
+    """
+  end
+end


### PR DESCRIPTION
### Notes
- add `CoElixirWorkerSpawner` that spawns `CoElixir.Worker`
- use `handle_call` instead of `handle_cast`
- use `handle_continue` for successive operations
- switch between `--sname` and `--name` according to the worker name format
- rename messages to those more self-explanatory