### PR TITLE
CI: add Elixir version 1.16 (#356)

### DIFF
--- a/.github/actions/matrix_check.yml
+++ b/.github/actions/matrix_check.yml
@@ -1,3 +1,5 @@
 include:
   - otp-version: "26.1.2"
     elixir-version: "1.15.7"
+  - otp-version: "26.1.2"
+    elixir-version: "1.16.0-rc.1"

--- a/.github/actions/matrix_dependabot.yml
+++ b/.github/actions/matrix_dependabot.yml
@@ -14,3 +14,18 @@ include:
   - otp-version: "26.1.2"
     elixir-version: "1.15.7"
     working-directory: benchmarks/onnx_to_axon_bench
+  - otp-version: "26.1.2"
+    elixir-version: "1.16.0-rc.1"
+    working-directory: utilities/node_activator
+  - otp-version: "26.1.2"
+    elixir-version: "1.16.0-rc.1"
+    working-directory: utilities/spawn_co_elixir
+  - otp-version: "26.1.2"
+    elixir-version: "1.16.0-rc.1"
+    working-directory: utilities/http_downloader
+  - otp-version: "26.1.2"
+    elixir-version: "1.16.0-rc.1"
+    working-directory: benchmarks/distributed_computing_bench
+  - otp-version: "26.1.2"
+    elixir-version: "1.16.0-rc.1"
+    working-directory: benchmarks/onnx_to_axon_bench

--- a/.github/actions/matrix_for_self_hosted_macos.yml
+++ b/.github/actions/matrix_for_self_hosted_macos.yml
@@ -14,3 +14,18 @@ include:
   - otp-version: "26.1.2"
     elixir-version: "1.15.7"
     working-directory: benchmarks/onnx_to_axon_bench
+  - otp-version: "26.1.2"
+    elixir-version: "1.16.0-rc.1"
+    working-directory: utilities/node_activator
+  - otp-version: "26.1.2"
+    elixir-version: "1.16.0-rc.1"
+    working-directory: utilities/spawn_co_elixir
+  - otp-version: "26.1.2"
+    elixir-version: "1.16.0-rc.1"
+    working-directory: utilities/http_downloader
+  - otp-version: "26.1.2"
+    elixir-version: "1.16.0-rc.1"
+    working-directory: benchmarks/distributed_computing_bench
+  - otp-version: "26.1.2"
+    elixir-version: "1.16.0-rc.1"
+    working-directory: benchmarks/onnx_to_axon_bench

--- a/.github/actions/matrix_reduced_test_1.yml
+++ b/.github/actions/matrix_reduced_test_1.yml
@@ -5,3 +5,7 @@ include:
     elixir-version: '1.15.7'
   - otp-version: '26.1.2'
     elixir-version: '1.15.7'
+  - otp-version: '24.3.4.13'
+    elixir-version: "1.16.0-rc.1"
+  - otp-version: '26.1.2'
+    elixir-version: "1.16.0-rc.1"

--- a/.github/actions/matrix_reduced_test_2.yml
+++ b/.github/actions/matrix_reduced_test_2.yml
@@ -5,3 +5,5 @@ include:
     elixir-version: '1.14.5'
   - otp-version: '26.1.2'
     elixir-version: '1.14.5'
+  - otp-version: '25.3.2.6'
+    elixir-version: "1.16.0-rc.1"

--- a/.github/actions/matrix_test.yml
+++ b/.github/actions/matrix_test.yml
@@ -3,11 +3,17 @@ include:
     elixir-version: '1.14.5'
   - otp-version: '24.3.4.13'
     elixir-version: '1.15.7'
+  - otp-version: '24.3.4.13'
+    elixir-version: "1.16.0-rc.1"
   - otp-version: '25.3.2.6'
     elixir-version: '1.14.5'
   - otp-version: '25.3.2.6'
     elixir-version: '1.15.7'
+  - otp-version: '25.3.2.6'
+    elixir-version: "1.16.0-rc.1"
   - otp-version: '26.1.2'
     elixir-version: '1.14.5'
   - otp-version: '26.1.2'
     elixir-version: '1.15.7'
+  - otp-version: '26.1.2'
+    elixir-version: "1.16.0-rc.1"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Each has their own README, which you can access above to learn more.
 Supported Erlang/OTP and Elixir versions:
 
 * OTP: 24, 25, 26
-* Elixir: 1.14, 1.15
+* Elixir: 1.14, 1.15, 1.16
 
 ## Supported Platforms
 


### PR DESCRIPTION
* docs: add Elixir 1.16 to supported versions

* ci: add Elixir 1.16 to matrices

* ci: update Elixir version to main, temporally

* change main to 1.16.0-rc.1